### PR TITLE
[Testframe] 框架因缓存问题导致较多用例重复失败，即使�

### DIFF
--- a/test/tools/br/js/run.js
+++ b/test/tools/br/js/run.js
@@ -107,7 +107,8 @@ function run(kiss, runnext) {
 	/**
 	 * 初始化执行区并通过嵌入iframe启动用例执行
 	 */
-	var url = 'run.php?case=' + kiss + '&' + location.search.substring(1);
+	var url = 'run.php?case=' + kiss + '&time=' + new Date().getTime() + "&"
+	+ location.search.substring(1);
 	// + (location.search.length > 0 ? '&' + location.search.substring(1)
 	// : '');
 

--- a/test/tools/br/run.php
+++ b/test/tools/br/run.php
@@ -1,5 +1,6 @@
 <?php
 header("Content-type: text/html; charset=utf-8");
+header("Cache-Control: no-cache, max-age=10, must-revalidate");
 if(!array_key_exists('quirk', $_GET)){
 	print '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">';
 };


### PR DESCRIPTION
[Testframe] 框架因缓存问题导致较多用例重复失败，即使更新了用例
tools/br/js/run.js : run.php请求加上时间戳
tools/br/run.php : 设置header，10秒即过期
