### PR TITLE
在Table$select插件中加入对Table$title的判断

### DIFF
--- a/src/baidu/ui/Table/Table$select.js
+++ b/src/baidu/ui/Table/Table$select.js
@@ -85,7 +85,7 @@ baidu.object.extend(baidu.ui.Table.prototype, {
 			}
 		});
 		if(me.title && baidu.lang.isNumber(index)){//如果存在表格标题,生成全选checkbox
-			if(me.getTitleBody()){//这里和$title插件存在文件载入先后关联
+			if(me.getTitleBody && me.getTitleBody()){//这里和$title插件存在文件载入先后关联
 				me._createTitleScelect(index);
 			}else{
 				me.addEventListener("titleload", function(){


### PR DESCRIPTION
[BugFix] 用户在没有导入Table$title时只导入Table$select时会报错
Table$select.js : 在_createSelect中增加me.getTitleBody的判断
