### PR TITLE
去掉多余的文字信息

### DIFF
--- a/src/baidu/ui/getAttribute.js
+++ b/src/baidu/ui/getAttribute.js
@@ -15,8 +15,6 @@
 
 /**
  *  从指定的dom元素中获取ui控件的属性值
- *
- *  todo: &datasource支持
  */
 
 baidu.ui.getAttribute = function(element){


### PR DESCRIPTION
[Change] 多余的没有用的文字信息在文档中使用户看到乱码
getAttribute : 去掉注释中的多余文字
